### PR TITLE
🔧 Configure class-methods-use-this and add func-style

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -43,3 +43,7 @@ rules:
   "@typescript-eslint/return-await": error
   "@typescript-eslint/sort-type-constituents": error
   "@typescript-eslint/switch-exhaustiveness-check": error
+
+  func-style:
+    - error
+    - declaration

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -15,7 +15,10 @@ parserOptions:
 plugins:
   - "@typescript-eslint"
 rules:
-  "@typescript-eslint/class-methods-use-this": error
+  "@typescript-eslint/class-methods-use-this":
+    - error
+    - ignoreClassesThatImplementAnInterface: true
+      ignoreOverrideMethods: true
   "@typescript-eslint/consistent-type-exports": error
   "@typescript-eslint/consistent-type-imports":
     - error


### PR DESCRIPTION
This pull request includes the following changes:

- Configure the class-methods-use-this rule in the .eslintrc.yaml file to ignore classes that implement an interface and override methods.

- Add the func-style rule to the .eslintrc.yaml file to enforce the use of function declarations.
