### PR TITLE
⚗️ TypeScript-only package with Node 22.6

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -17,7 +17,7 @@ jobs:
           version: latest
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: nightly
           cache: pnpm
       - run: pnpm install
       - run: pnpm run docs

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -17,7 +17,7 @@ jobs:
           version: latest
       - uses: actions/setup-node@v4
         with:
-          node-version: nightly
+          node-version: 23-nightly
           cache: pnpm
       - run: pnpm install
       - run: pnpm run docs

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -17,7 +17,7 @@ jobs:
           version: latest
       - uses: actions/setup-node@v4
         with:
-          node-version: 23-nightly
+          node-version: ">=22.6"
           cache: pnpm
       - run: pnpm install
       - run: pnpm run docs

--- a/.github/workflows/node.js.yaml
+++ b/.github/workflows/node.js.yaml
@@ -17,7 +17,7 @@ jobs:
           version: latest
       - uses: actions/setup-node@v4
         with:
-          node-version: 23-nightly
+          node-version: ">=22.6"
           cache: pnpm
       - run: pnpm install --frozen-lockfile --strict-peer-dependencies
       - run: pnpm run build --noEmit

--- a/.github/workflows/node.js.yaml
+++ b/.github/workflows/node.js.yaml
@@ -17,7 +17,7 @@ jobs:
           version: latest
       - uses: actions/setup-node@v4
         with:
-          node-version: nightly
+          node-version: 23-nightly
           cache: pnpm
       - run: pnpm install --frozen-lockfile --strict-peer-dependencies
       - run: pnpm run build --noEmit

--- a/.github/workflows/node.js.yaml
+++ b/.github/workflows/node.js.yaml
@@ -17,7 +17,7 @@ jobs:
           version: latest
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: nightly
           cache: pnpm
       - run: pnpm install --frozen-lockfile --strict-peer-dependencies
       - run: pnpm run build --noEmit

--- a/.github/workflows/pnpm-publish.yaml
+++ b/.github/workflows/pnpm-publish.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: 23-nightly
+          node-version: ">=22.6"
       - run: pnpm install
       - run: pnpm build
 

--- a/.github/workflows/pnpm-publish.yaml
+++ b/.github/workflows/pnpm-publish.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: latest
+          node-version: nightly
       - run: pnpm install
       - run: pnpm build
 

--- a/.github/workflows/pnpm-publish.yaml
+++ b/.github/workflows/pnpm-publish.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: nightly
+          node-version: 23-nightly
       - run: pnpm install
       - run: pnpm build
 

--- a/.github/workflows/pnpm-version-patch.yaml
+++ b/.github/workflows/pnpm-version-patch.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: latest
+          node-version: nightly
       - name: Configure Git, patch, release and push
         run: |
           git config user.name 'github-actions[bot]'

--- a/.github/workflows/pnpm-version-patch.yaml
+++ b/.github/workflows/pnpm-version-patch.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: nightly
+          node-version: 23-nightly
       - name: Configure Git, patch, release and push
         run: |
           git config user.name 'github-actions[bot]'

--- a/.github/workflows/pnpm-version-patch.yaml
+++ b/.github/workflows/pnpm-version-patch.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: pnpm
-          node-version: 23-nightly
+          node-version: ">=22.6"
       - name: Configure Git, patch, release and push
         run: |
           git config user.name 'github-actions[bot]'

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,6 @@ RUN corepack enable
 COPY . /app
 WORKDIR /app
 
-FROM base AS prod-deps
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
 
-FROM base AS build
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
-RUN pnpm run build
-
-FROM base
-COPY --from=prod-deps /app/node_modules /app/node_modules
-COPY --from=build /app/dist /app/dist
 CMD [ "pnpm", "start" ]

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 	"scripts": {
 		"build": "tsc",
 		"clean": "rm -rf dist docs node_modules tsconfig.tsbuildinfo",
-		"dev": "tsx ./src/main.ts",
+		"dev": "node --experimental-strip-types ./src/main.ts",
 		"docker": "pnpm run docker:build && pnpm run docker:run",
 		"docker:build": "docker build -t gigachad.ts .",
 		"docker:kill": "docker ps --format '{{.Image}} {{.ID}}' | grep gigachad.ts | awk '{print $2}' | xargs docker kill",
@@ -62,7 +62,6 @@
 		"globals": "^15.9.0",
 		"markdownlint-cli2": "^0.13.0",
 		"prettier": "^3.3.3",
-		"tsx": "^4.16.5",
 		"typedoc": "^0.26.5",
 		"typescript": "^5.5.4",
 		"typescript-eslint": "^7.16.1",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
 		}
 	],
 	"files": [
-		"dist",
-		"!dist/**/*.test.*"
+		"src",
+		"!src/**/*.test.*"
 	],
-	"main": "dist/index.js",
+	"main": "src/index.ts",
 	"bin": {
-		"gigachad": "dist/main.js"
+		"gigachad": "src/main.ts"
 	},
 	"repository": "github:NatoBoram/gigachad.ts",
 	"scripts": {
@@ -52,7 +52,7 @@
 		"format": "prettier --write .",
 		"lint": "eslint . && markdownlint-cli2 \"**/*.md\" && prettier --check .",
 		"lint:fix": "eslint --fix --quiet .; markdownlint-cli2 \"**/*.md\" --fix; prettier --list-different --write .",
-		"start": "node dist/main.js",
+		"start": "node --experimental-strip-types src/main.ts",
 		"test": "vitest"
 	},
 	"devDependencies": {
@@ -74,10 +74,10 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"default": "./dist/index.js"
+			"types": "./src/index.ts",
+			"default": "./src/index.ts"
 		}
 	},
-	"types": "dist/index.d.ts",
-	"module": "dist/index.js"
+	"types": "src/index.ts",
+	"module": "src/index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"vitest": "^2.0.5"
 	},
 	"engines": {
-		"node": ">=23.0.0-nightly202407253de7a4c374"
+		"node": ">=22.6"
 	},
 	"type": "module",
 	"exports": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
 		"typescript-eslint": "^7.16.1",
 		"vitest": "^2.0.5"
 	},
+	"engines": {
+		"node": ">=23.0.0-nightly202407253de7a4c374"
+	},
 	"type": "module",
 	"exports": {
 		".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
-      tsx:
-        specifier: ^4.16.5
-        version: 4.16.5
       typedoc:
         specifier: ^0.26.5
         version: 0.26.5(typescript@5.5.4)
@@ -640,9 +637,6 @@ packages:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
 
-  get-tsconfig@4.7.6:
-    resolution: {integrity: sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -899,9 +893,6 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -998,11 +989,6 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
-
-  tsx@4.16.5:
-    resolution: {integrity: sha512-ArsiAQHEW2iGaqZ8fTA1nX0a+lN5mNTyuGRRO6OW3H/Yno1y9/t1f9YOI1Cfoqz63VAthn++ZYcbDP7jPflc+A==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1689,10 +1675,6 @@ snapshots:
 
   get-stream@8.0.1: {}
 
-  get-tsconfig@4.7.6:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -1914,8 +1896,6 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
-
   reusify@1.0.4: {}
 
   rollup@4.19.2:
@@ -2000,13 +1980,6 @@ snapshots:
   ts-api-utils@1.3.0(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
-
-  tsx@4.16.5:
-    dependencies:
-      esbuild: 0.21.5
-      get-tsconfig: 4.7.6
-    optionalDependencies:
-      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 import { test } from "vitest"
-import * as index from "./index.js"
+import * as index from "./index.ts"
 
 test("index", ({ expect }) => {
 	expect(index).toBeDefined()

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,4 +13,4 @@
  * @module
  */
 
-export * from "./main.js"
+export * from "./main.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
 		"rootDir": "./src",
 		"moduleResolution": "NodeNext",
 		"typeRoots": ["./node_modules/@types", "./src/types"],
+		"allowImportingTsExtensions": true,
 		"resolvePackageJsonExports": true,
 		"resolvePackageJsonImports": true,
 		"resolveJsonModule": true,
@@ -26,6 +27,7 @@
 		"declarationMap": true,
 		"sourceMap": true,
 		"outDir": "./dist",
+		"noEmit": true,
 		"downlevelIteration": true,
 
 		/* Interop Constraints */


### PR DESCRIPTION
An attempt at using TypeScript without a compilation process

### 📝 Description

<!-- Why this pull request? -->

Node.js added `--experimental-strip-types` in `v22.6.0`, which allows it to run TypeScript files without a compilation process.

<!-- Why is this the best solution? -->

Avoiding the build step to run Node.js TypeScript applications could be very useful for all projects running directly with Node, like Express applications. It can drastically simplify the deployment process, particularly with Cloud Functions.

However, published CLI apps might not work if `--experimental-strip-types` cannot be passed to files listed in `bin`. Additionally, published libraries will not work on the browser unless a bundler is used, which is already expected from modern front-end development.

I am expecting `--experimental-strip-types` to be the default behaviour in the release of Node 23.

Overall, it seems like a TypeScript-only package would cause a very minimal amount of friction in the ecosystem due to browsers always being late to the party.

<!-- What you did -->

* Enable `allowImportingTsExtensions` and `noEmit` in `tsconfig.json`
* Change imports for `.ts`
* Export directly from `src`
* Set `engines` to `node` `>=22.6`
* Updated GitHub Workflows to `node-version: >= 22.6`
* Uninstall `tsx` from the `devDependencies`

### 📓 References

* https://github.com/nodejs/node/pull/53725
* Experienced a blocker due to https://github.com/actions/setup-node/issues/761
* https://nodejs.org/en/blog/release/v22.6.0
* https://nodejs.org/api/typescript.html
* https://nodejs.org/api/errors.html#err_unsupported_node_modules_type_stripping
* https://github.com/denoland/deno/issues/16790
* https://jsr.io

> #### [Type stripping in dependencies](https://nodejs.org/api/typescript.html#type-stripping-in-dependencies)
> 
> To discourage package authors from publishing packages written in TypeScript, Node.js will by default refuse to handle TypeScript files inside folders under a `node_modules` path.