### PR TITLE
➖ Drop `tsx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The most gigachad project setup for TypeScript.
 - Lint markdown with [markdownlint](https://github.com/DavidAnson/markdownlint)
 - Manage packages with [pnpm](https://github.com/pnpm/pnpm)
 - Pledge your respect with the [Contributor Covenant](https://github.com/EthicalSource/contributor_covenant)
-- Run with [tsx](https://github.com/privatenumber/tsx)
+- Run with ~~[tsx](https://github.com/privatenumber/tsx)~~ [Node.js](https://nodejs.org/api/typescript.html#type-stripping)
 - Test units with [Vitest](https://github.com/vitest-dev/vitest)
 - Update dependencies with [Dependabot](https://github.com/dependabot/dependabot-core)
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 	"scripts": {
 		"build": "tsc",
 		"clean": "rm -rf dist docs node_modules tsconfig.tsbuildinfo",
-		"dev": "tsx ./src/main.ts",
+		"dev": "node ./src/main.ts",
 		"docker": "pnpm run docker:build && pnpm run docker:run",
 		"docker:build": "docker build -t gigachad.ts .",
 		"docker:kill": "docker ps --format '{{.Image}} {{.ID}}' | grep gigachad.ts | awk '{print $2}' | xargs docker kill",
@@ -63,7 +63,6 @@
 		"globals": "^15.14.0",
 		"markdownlint-cli2": "^0.17.2",
 		"prettier": "^3.4.2",
-		"tsx": "^4.19.2",
 		"typedoc": "^0.27.6",
 		"typescript": "5.7.3",
 		"typescript-eslint": "^8.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.19.2
       typedoc:
         specifier: ^0.27.6
         version: 0.27.6(typescript@5.7.3)
@@ -1926,6 +1923,7 @@ snapshots:
       '@esbuild/win32-arm64': 0.23.1
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
+    optional: true
 
   esbuild@0.24.2:
     optionalDependencies:
@@ -2077,6 +2075,7 @@ snapshots:
   get-tsconfig@4.8.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -2472,7 +2471,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   reusify@1.0.4: {}
 
@@ -2553,6 +2553,7 @@ snapshots:
       get-tsconfig: 4.8.1
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
We can now use `node` directly.

* https://nodejs.org/api/typescript.html#type-stripping

Now requires Node 23.