### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build_pages:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     if: github.actor != 'nektos/act'


### PR DESCRIPTION
Potential fix for [https://github.com/NatoBoram/gigachad.ts/security/code-scanning/1](https://github.com/NatoBoram/gigachad.ts/security/code-scanning/1)

To fix the problem, add a `permissions` block to the `build_pages` job in `.github/workflows/github-pages.yaml` that restricts the `GITHUB_TOKEN` to the minimum required permissions. Since the job only checks out code, installs dependencies, runs tests, and uploads an artifact, it only needs read access to repository contents. Therefore, add `permissions: contents: read` to the `build_pages` job, directly under the job name and before `runs-on`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
