### PR TITLE
👷 Add Docker and Docker Compose to Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -38,3 +38,19 @@ updates:
       timezone: America/Toronto
     commit-message:
       prefix: "⬆️ "
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+      timezone: America/Toronto
+    commit-message:
+      prefix: "⬆️ "
+
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: monthly
+      timezone: America/Toronto
+    commit-message:
+      prefix: "⬆️ "

--- a/README.md
+++ b/README.md
@@ -131,3 +131,13 @@ To publish on NPM, you'll need to provide your NPM token.
 4. Save your new token in the `npm-public-registry` environment in a new secret called `NODE_AUTH_TOKEN`
 
 You can also create the environments `github-packages-registry` and `github-releases` and the publishing workflow will automatically use them.
+
+## Dependabot labels
+
+You can import some relevant labels from Dependabot with these commands:
+
+```sh
+gh label create dependencies --color '#0366d6' --description 'Pull requests that update a dependency file' --force
+gh label create github_actions --color '#000000' --description 'Pull requests that update GitHub Actions code' --force
+gh label create javascript --color '#168700' --description 'Pull requests that update Javascript code' --force
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Documentation
  - Added guidance on Dependabot labels, including commands to create labels for dependencies, GitHub Actions, and JavaScript.

- Chores
  - Configured automated dependency updates for Docker and Docker Compose with a monthly schedule, Toronto timezone, and a commit message prefix for update PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->