### PR TITLE
🚀 Deploy to IPFS

### DIFF
--- a/.github/workflows/ipfs.yaml
+++ b/.github/workflows/ipfs.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: ipfs/ipfs-deploy-action@v1
         with:
           github-token: ${{ github.token }}
-          ipfs-add-options: --chunker=buzhash --cid-version=1 --hash=blake3 --pin=false --recursive
+          ipfs-add-options: --chunker=buzhash --cid-version=1 --hash=blake3 --pin=false
           kubo-api-auth: ${{ secrets.KUBO_API_AUTH }}
           kubo-api-url: ${{ secrets.KUBO_API_URL }}
           path-to-deploy: docs

--- a/.github/workflows/ipfs.yaml
+++ b/.github/workflows/ipfs.yaml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/download-artifact@v5
         with:
           name: docs
+          path: docs
 
       - id: deploy
         uses: ipfs/ipfs-deploy-action@v1

--- a/.github/workflows/ipfs.yaml
+++ b/.github/workflows/ipfs.yaml
@@ -1,0 +1,67 @@
+name: IPFS
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build_ipfs:
+    permissions:
+      contents: read
+
+    if: github.actor != 'nektos/act'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - uses: actions/setup-node@v5
+        with:
+          node-version: latest
+          cache: pnpm
+      - run: pnpm install
+
+      - run: pnpm run docs
+      - run: pnpm run test:coverage
+      - run: cp --force --recursive coverage docs/coverage
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: docs
+          if-no-files-found: error
+
+  deploy_ipfs:
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+
+    needs: build_ipfs
+
+    runs-on: ubuntu-latest
+
+    environment:
+      name: ipfs
+      url: https://${{ steps.deploy.outputs.cid }}.ipfs.dweb.link
+
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: docs
+
+      - id: deploy
+        uses: ipfs/ipfs-deploy-action@v1
+        with:
+          github-token: ${{ github.token }}
+          ipfs-add-options: --chunker=buzhash --cid-version=1 --hash=blake3 --pin=false --recursive
+          kubo-api-auth: ${{ secrets.KUBO_API_AUTH }}
+          kubo-api-url: ${{ secrets.KUBO_API_URL }}
+          path-to-deploy: docs

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Here's a few useful commands to delete what you don't need.
 
 ```sh
 # AI
-rm -rf .coderabbit.yaml .gemini .github/copilot-instructions.md .github/instructions .github/workflows/copilot-setup-steps.yaml .vscode/mcp.json
+rm -rf .coderabbit.yaml .gemini .github/copilot-instructions.md .github/instructions .github/workflows/copilot-setup-steps.yaml .vscode/mcp.json GEMINI.md
 ```
 
 ```sh
@@ -83,6 +83,11 @@ rm -f .github/workflows/github-pages.yaml typedoc.json
 # Funding
 pnpm pkg delete funding
 rm -f .github/FUNDING.yaml
+```
+
+```sh
+# IPFS
+rm -rf .github/workflows/ipfs.yaml
 ```
 
 ```sh


### PR DESCRIPTION
Huh, I would've expected IPNS support to be there. This way, I would set the IPFS CID as a deployment URL but then use a badge that links to a IPNS record in `README.md`.

* https://github.com/ipfs/ipfs-deploy-action/issues/7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Documentation site is now published to IPFS with a shareable deployment URL.
  - Test coverage reports are bundled into the published docs.

- Chores
  - Automated build, test, and docs packaging added to CI with safeguards for local runners.

- Documentation
  - README updated with IPFS cleanup instructions.
  - Expanded removal example to include GEMINI.md.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->